### PR TITLE
Support for ARM64 binaries as well as kubescape.exe

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -213,10 +213,19 @@ async function downloadFile(url : string, downloadDir : string,
  * @returns The right asset name depended on the system
  */
 function chooseKubescapeAsset() : string {
+    let prefix = "kubescape"
+    switch(os.arch()) {
+        case 'arm64':
+            prefix += "-arm64"
+            break
+        default:
+            break
+    }
+
     const variants: { [key: string]: string } = {
-        "linux": "kubescape-ubuntu-latest",
-        "darwin": "kubescape-macos-latest",
-        "win32": "kubescape-windows-latest"
+        "linux": prefix + "-ubuntu-latest",
+        "darwin": prefix + "-macos-latest",
+        "win32": prefix + ".exe"
     };
 
     return variants[os.platform()];

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,7 +7,7 @@ import { KubescapeApi, KubescapeUi, IKubescapeConfig } from '../src/index'
 const seconds = (n : number) => n * 1000
 const minutes = (n : number) => n * 1000 * 60 
 
-const DEFAULT_KUBESCAPE_VERSION = "v2.0.176";
+const DEFAULT_KUBESCAPE_VERSION = "v2.3.1";
 
 class TestUi implements KubescapeUi {
     info(msg: string): void {


### PR DESCRIPTION
As ARM64 binaries as well as kubescape.exe has been introduced in the upstream:
- https://github.com/kubescape/kubescape/pull/1148
- https://github.com/kubescape/kubescape/pull/1169

Wait for:
- [vscode-kubescape](https://github.com/kubescape/vscode-kubescape/blob/master/src/Kubescape/globals.ts#LL1C1-L1C1) kubescape upgrade to version greater than v2.3.0 https://github.com/kubescape/vscode-kubescape/pull/12
- [node-kubescape](https://github.com/kubescape/lens-extension/blob/master/src/utils/consts.ts#L2) kubescape upgrade to version greater than v2.3.0 https://github.com/kubescape/lens-extension/pull/16