### PR TITLE
For air-gapped: only check kubescape version for "latest" request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -855,7 +855,7 @@ export class KubescapeApi {
             /* ---------------------------------------------------------------*/
             ui.debug(`Kubescape requested version: ${configs.version}`)
 
-            if (!needsUpdate) {
+            if (!needsUpdate && configs.version === "latest") {
                 /* kubescape exists - check version match */
                 this._versionInfo = await this.getKubescapeVersion()
                 if (configs.version !== this.version) {


### PR DESCRIPTION
Hi, thanks for this useful extension and our group are all eager to use it.

Since we are under an air-gapped environment, we already prepared a proxy for VS Code extension installing. However, since the extension will try to check the kubescape binary version during initialization, it is still stucked and we has no other methods to solve it.

I think maybe only to check latest version when user fill in "latest" option in the extension config is a reasonable solution ?

Please let me know your thoughts, thx :)

